### PR TITLE
Update consultant pattern retrieval to filter by consultant ID

### DIFF
--- a/src/controllers/consultant_pattern.controller.ts
+++ b/src/controllers/consultant_pattern.controller.ts
@@ -123,7 +123,8 @@ export const getAllConsultantPatterns = async (req: Request, res: Response, next
 // Get all consultant patterns in week
 export const getAllConsultantPatternsInWeek = async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const result = await consultantPatternService.getAllConsultantPatternsInWeek()
+    const { consultant_id } = req.query
+    const result = await consultantPatternService.getAllConsultantPatternsInWeek(consultant_id as string)
     res.status(HTTP_STATUS.OK).json({
       message: CONSULTANT_PATTERNS_MESSAGES.CONSULTANT_PATTERNS_RETRIEVED_SUCCESS,
       result

--- a/src/routes/consultant_pattern.route.ts
+++ b/src/routes/consultant_pattern.route.ts
@@ -52,7 +52,7 @@ consultantPatternRoute.get(
 */
 consultantPatternRoute.get(
   '/get-all-consultant-patterns-in-week',
-  restrictTo(Role.ADMIN),
+  restrictTo(Role.ADMIN, Role.CUSTOMER),
   wrapRequestHandler(getAllConsultantPatternsInWeek)
 )
 

--- a/src/services/consultant_pattern.service.ts
+++ b/src/services/consultant_pattern.service.ts
@@ -92,10 +92,11 @@ export class ConsultantPatternService {
     })
   }
 
-  async getAllConsultantPatternsInWeek(): Promise<ConsultantPattern[]> {
+  async getAllConsultantPatternsInWeek(consultant_id: string): Promise<ConsultantPattern[]> {
     const consultantPatterns = await consultantPatternRepository
       .createQueryBuilder('consultant_pattern')
       .where('date_trunc(\'week\', "consultant_pattern"."date") = date_trunc(\'week\', NOW())')
+      .andWhere('consultant_pattern.account_id = :consultant_id', { consultant_id })
       .orderBy('"consultant_pattern"."date"', 'DESC')
       .getMany()
     return consultantPatterns


### PR DESCRIPTION
- Modified the `getAllConsultantPatternsInWeek` controller to accept a `consultant_id` query parameter for filtering results.
- Updated the service method to include a condition for retrieving patterns specific to the provided consultant ID.
- Adjusted route permissions to allow both ADMIN and CUSTOMER roles to access the endpoint, enhancing accessibility.